### PR TITLE
Add backward compatibility to the 0.2 series.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@ ChangeLog
 =========
 
 
+0.3.2 (unreleased)
+------------------
+
+* Add backward compatibility to the ``0.2`` series following territory utils
+  split out of the ``address`` module. See #8.
+
+
 0.3.1 (2015-03-05)
 ------------------
 

--- a/postal_address/address.py
+++ b/postal_address/address.py
@@ -22,15 +22,81 @@ u""" Utilities for address parsing and rendering.
 
 .. data:: COUNTRY_ALIASES
 
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
 .. data:: SUBDIVISION_ALIASES
 
-   Map subdivision ISO 3166-2 codes to their officially assigned ISO 3166-1
-   alpha-2 country codes. Source: https://en.wikipedia.org/wiki
-   /ISO_3166-2#Subdivisions_included_in_ISO_3166-1
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
 
 .. data:: REVERSE_MAPPING
 
-   Reverse index of the SUBDIVISION_ALIASES mapping defined above.
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: supported_territory_codes()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: normalize_territory_code()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: normalize_country_code()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: default_subdivision_code()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: territory_tree()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: territory_parents()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: territory_parents_codes()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
+.. function:: country_aliases()
+
+   .. deprecated:: 0.3.0
+
+      Import from ``postal_address.territory`` instead of
+      ``postal_address.address``.
+
 """
 
 from __future__ import (unicode_literals, print_function, absolute_import,
@@ -41,12 +107,60 @@ try:
 except NameError:  # pragma: no cover
     basestring = (str, bytes)
 
+import warnings
+
 from pycountry import countries, subdivisions
 from slugify import slugify
 
 from .territory import (
     country_from_subdivision, default_subdivision_code,
     normalize_territory_code, territory_parents)
+# Territory utils below are now used locally but provides backward-
+# compatibility following their splitting out of the ``address`` module.
+# See issue #8 and commit b7eb50.
+warnings.warn(
+    'COUNTRY_ALIASES has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'SUBDIVISION_ALIASES has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'REVERSE_MAPPING has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'supported_territory_codes has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'normalize_territory_code has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'normalize_country_code has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'default_subdivision_code has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'territory_tree has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'territory_parents has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'territory_parents_codes has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+warnings.warn(
+    'country_aliases has been moved from postal_address.address to '
+    'postal_address.territory.', DeprecationWarning)
+from .territory import (
+    COUNTRY_ALIASES,
+    SUBDIVISION_ALIASES,
+    REVERSE_MAPPING,
+    supported_territory_codes,
+    normalize_country_code,
+    territory_tree,
+    territory_parents_codes,
+    country_aliases,
+)
 
 
 class Address(object):

--- a/postal_address/address.py
+++ b/postal_address/address.py
@@ -112,10 +112,9 @@ import warnings
 from pycountry import countries, subdivisions
 from slugify import slugify
 
-from .territory import (
-    country_from_subdivision, default_subdivision_code,
-    normalize_territory_code, territory_parents)
-# Territory utils below are now used locally but provides backward-
+from .territory import country_from_subdivision
+
+# Territory utils below are not used locally but provides backward-
 # compatibility following their splitting out of the ``address`` module.
 # See issue #8 and commit b7eb50.
 warnings.warn(
@@ -127,39 +126,10 @@ warnings.warn(
 warnings.warn(
     'REVERSE_MAPPING has been moved from postal_address.address to '
     'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'supported_territory_codes has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'normalize_territory_code has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'normalize_country_code has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'default_subdivision_code has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'territory_tree has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'territory_parents has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'territory_parents_codes has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
-warnings.warn(
-    'country_aliases has been moved from postal_address.address to '
-    'postal_address.territory.', DeprecationWarning)
 from .territory import (
     COUNTRY_ALIASES,
     SUBDIVISION_ALIASES,
     REVERSE_MAPPING,
-    supported_territory_codes,
-    normalize_country_code,
-    territory_tree,
-    territory_parents_codes,
-    country_aliases,
 )
 
 
@@ -642,3 +612,148 @@ def subdivision_metadata(subdivision):
             Address.BASE_COMPONENT_IDS)
 
     return metadata
+
+
+def supported_territory_codes():
+    """ Return a set of recognized territory codes.
+
+    Are supported:
+        * ISO 3166-1 alpha-2 country codes
+        * ISO 3166-2 subdivision codes
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'supported_territory_codes has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import supported_territory_codes
+    return supported_territory_codes()
+
+
+def normalize_territory_code(territory_code, resolve_aliases=True):
+    """ Normalize any string into a territory code.
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'normalize_territory_code has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import normalize_territory_code
+    return normalize_territory_code(
+        territory_code, resolve_aliases=resolve_aliases)
+
+
+def normalize_country_code(subdivision_code):
+    """ Return the normalized country code of a subdivisions.
+
+    For subdivisions having their own ISO 3166-1 alpha-2 country code, returns
+    the later instead of the parent ISO 3166-2 top entry.
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'normalize_country_code has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import normalize_country_code
+    return normalize_country_code(subdivision_code)
+
+
+def default_subdivision_code(country_code):
+    """ Return the default subdivision code of a country.
+
+    The result can be guessed only if there is a 1:1 mapping between a country
+    code and a subdivision code.
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'default_subdivision_code has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import default_subdivision_code
+    return default_subdivision_code(country_code)
+
+
+def territory_tree(territory_code, include_country=True):
+    """ Return the whole hierarchy of territories, up to the country.
+
+    Values returned by the generator are either subdivisions or country
+    objects, starting from the provided subdivision and up its way to
+    the top administrative territory (i.e. country).
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'territory_tree has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import territory_tree
+    return territory_tree(
+        territory_code, include_country=include_country)
+
+
+def territory_parents(territory_code, include_country=True):
+    """ Return the whole hierarchy of territories, up to the country.
+
+    Values returned by the generator are either subdivisions or country
+    objects, starting from the provided territory and up its way to the top
+    administrative territory (i.e. country).
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'territory_parents has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import territory_parents
+    return territory_parents(
+        territory_code, include_country=include_country)
+
+
+def territory_parents_codes(territory_code, include_country=True):
+    """ Like territory_parents but return normalized codes instead of objects.
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'territory_parents_codes has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import territory_parents_codes
+    return territory_parents_codes(
+        territory_code, include_country=include_country)
+
+
+def country_aliases(territory_code):
+    """ List valid country code aliases of a territory.
+
+    Mainly used to check if a non-normalized country code can safely be
+    replaced by its normalized form.
+
+    .. deprecated:: 0.3.0
+
+       Import from ``postal_address.territory`` instead of
+       ``postal_address.address``.
+    """
+    warnings.warn(
+        'country_aliases has been moved from postal_address.address '
+        'to postal_address.territory.', DeprecationWarning)
+    from .territory import country_aliases
+    return country_aliases(territory_code)


### PR DESCRIPTION
Follows territory utils split out of the ``address`` module. See #8.